### PR TITLE
Fix reference error on empty given names

### DIFF
--- a/components/CiteEngine.js
+++ b/components/CiteEngine.js
@@ -164,7 +164,8 @@ export const citation_state =
       const bib = mbiblios[id]
       let x = this.state.cite.data[bidx]
       const etal = (x.author.length <= 1 )? "" : " et al."
-      const short_bib = x.author[0].given[0] + ". " + x.author[0].family + etal +" , " + x.title
+      const name = (x.author[0].given ? x.author[0].given[0] + ". " : "") + x.author[0].family;
+      const short_bib = name + etal + ", " + x.title
       
       if (i < nknow)
       {


### PR DESCRIPTION
Previously, creating references were breaking if an entry did not provide a "given name".

This happens for the following case:

```bibtex
@online{SampleEntry,
  author        = {{ENTITYNAME}},
  date          = {2024-04-27},
  title         = {Sample Title}
}
```

The result does not provide a given name, therefore referencing it in JavaScript breaks this entry and all the following entries.

This is fixed by only using the given name if present.